### PR TITLE
Fix crafting not using placed crafting table

### DIFF
--- a/src/main/java/adris/altoclef/tasks/construction/PlaceBlockNearbyTask.java
+++ b/src/main/java/adris/altoclef/tasks/construction/PlaceBlockNearbyTask.java
@@ -79,6 +79,7 @@ public class PlaceBlockNearbyTask extends Task {
         if (current != null && !_cantPlaceHere.test(current)) {
             if (equipBlock(mod)) {
                 if (mod.getControllerExtras().place()) {
+                    _justPlaced = current;
                     return null;
                 }
             }


### PR DESCRIPTION
Sometimes crafting doesn't use the crafting table that it places. This should prevent that in some cases. From my tests it has completely stopped the occurrences of it placing the crafting table and not using it, but I can't guarantee that in all cases. 