### PR TITLE
Added shouldEscapeLava option to BotBehaviour

### DIFF
--- a/src/main/java/adris/altoclef/chains/WorldSurvivalChain.java
+++ b/src/main/java/adris/altoclef/chains/WorldSurvivalChain.java
@@ -36,7 +36,7 @@ public class WorldSurvivalChain extends SingleTaskChain {
         handleDrowning(mod);
 
         // Lava Escape
-        if (isInLavaOhShit(mod)) {
+        if (isInLavaOhShit(mod) && mod.getBehaviour().shouldEscapeLava()) {
             setTask(new EscapeFromLavaTask());
             return 100;
         }

--- a/src/main/java/adris/altoclef/util/control/BotBehaviour.java
+++ b/src/main/java/adris/altoclef/util/control/BotBehaviour.java
@@ -34,12 +34,20 @@ public class BotBehaviour {
     }
 
     // Getter(s)
+    /**
+     * Returns the current state of Behaviour for escapeLava
+     * @return The current state of Behaviour for escapeLava
+     */
     public boolean shouldEscapeLava() {
         return current().escapeLava;
     }
 
     /// Parameters
 
+    /**
+     * If the bot should escape lava or not, part of WorldSurvivalChain
+     * @param allow True if the bot should escape lava
+     */
     public void setEscapeLava(boolean allow) {
         current().escapeLava = allow;
         current().applyState();

--- a/src/main/java/adris/altoclef/util/control/BotBehaviour.java
+++ b/src/main/java/adris/altoclef/util/control/BotBehaviour.java
@@ -33,7 +33,17 @@ public class BotBehaviour {
         push();
     }
 
+    // Getter(s)
+    public boolean shouldEscapeLava() {
+        return current().escapeLava;
+    }
+
     /// Parameters
+
+    public void setEscapeLava(boolean allow) {
+        current().escapeLava = allow;
+        current().applyState();
+    }
 
     public void setFollowDistance(double distance) {
         current().followOffsetDistance = distance;
@@ -233,6 +243,9 @@ public class BotBehaviour {
         // Hard coded stuff
         public RaycastContext.FluidHandling rayFluidHandling;
 
+        // Other necessary stuff
+        public boolean escapeLava = true;
+
         public State() {
             this(null);
         }
@@ -251,6 +264,7 @@ public class BotBehaviour {
                 avoidDodgingProjectile.addAll(toCopy.avoidDodgingProjectile);
                 excludeFromForceField.addAll(toCopy.excludeFromForceField);
                 forceFieldPlayers = toCopy.forceFieldPlayers;
+                escapeLava = toCopy.escapeLava;
             }
         }
 


### PR DESCRIPTION
Added this in case some Task need to player to die in lava, you can use `Altoclef.getBehaviour().setEscapeLava(bool)` to choose if the bot should automatically escape lava or not (part of WorldSurvivalChain). 