### PR TITLE
Altoclef will now trigger the bot to wander if a target entity is not…

### DIFF
--- a/src/main/java/adris/altoclef/tasks/entity/AbstractDoToEntityTask.java
+++ b/src/main/java/adris/altoclef/tasks/entity/AbstractDoToEntityTask.java
@@ -64,7 +64,7 @@ public abstract class AbstractDoToEntityTask extends Task implements ITaskRequir
         // Oof
         if (entity == null) {
             mod.getMobDefenseChain().resetForceField();
-            return null;
+            return _wanderTask;
         }
 
         double playerReach = mod.getModSettings().getEntityReachRange();
@@ -109,7 +109,7 @@ public abstract class AbstractDoToEntityTask extends Task implements ITaskRequir
             return new GetToEntityTask(entity, maintainDistance);
         }
 
-        return null;
+        return _wanderTask;
     }
 
     @Override


### PR DESCRIPTION
See bug report #160. This fix applies to other entities as well as it may get stuck in other situations. That should all be resolved now. 

Thanks to @adrisj7 for pointing out the changes that need made in the discord. 