### PR TITLE
Added travel using an elytra feature, the RepairToolTask and some edits around that

### DIFF
--- a/CataloguedResources.txt
+++ b/CataloguedResources.txt
@@ -219,6 +219,7 @@ fence_gate
 fermented_spider_eye
 fern
 fire_charge
+firework_rocket
 fishing_rod
 fletching_table
 flint

--- a/src/main/java/adris/altoclef/AltoClefCommands.java
+++ b/src/main/java/adris/altoclef/AltoClefCommands.java
@@ -16,6 +16,7 @@ public class AltoClefCommands {
                 new FollowCommand(),
                 new GiveCommand(),
                 new GotoCommand(),
+                new GotoWithElytraCommand(),
                 new IdleCommand(),
                 new CoordsCommand(),
                 new StatusCommand(),

--- a/src/main/java/adris/altoclef/BotBehaviour.java
+++ b/src/main/java/adris/altoclef/BotBehaviour.java
@@ -124,6 +124,16 @@ public class BotBehaviour {
         current().applyState();
     }
 
+    //Way of disabling MLG and MobDefense from a task
+    public boolean disableDefence() {
+        return current().disableDefence; //get value with mod.getBehaviour().disableDefence()
+    }
+
+    public void disableDefence(boolean value) { //and set value with mod.getBehaviour().disableDefence(true|false)
+        current().disableDefence = value;
+        current().applyState();
+    }
+
     public void setPauseOnLostFocus(boolean pauseOnLostFocus) {
         current().pauseOnLostFocus = pauseOnLostFocus;
         current().applyState();
@@ -246,6 +256,7 @@ public class BotBehaviour {
         // Alto Clef params
         public boolean exclusivelyMineLogs;
         public boolean forceFieldPlayers;
+        public boolean disableDefence;
         public List<Predicate<Entity>> avoidDodgingProjectile = new ArrayList<>();
 
         public List<Predicate<Entity>> excludeFromForceField = new ArrayList<>();

--- a/src/main/java/adris/altoclef/Playground.java
+++ b/src/main/java/adris/altoclef/Playground.java
@@ -204,9 +204,6 @@ public class Playground {
                     mod.runUserTask(new KillEntityTask(entity));
                 }
                 break;
-            case "elytra":
-                    mod.runUserTask(new GetToXZWithElytraTask(1000,1000));
-                break;
             case "craft":
                 // Test de-equip
                 new Thread(() -> {

--- a/src/main/java/adris/altoclef/Playground.java
+++ b/src/main/java/adris/altoclef/Playground.java
@@ -204,6 +204,9 @@ public class Playground {
                     mod.runUserTask(new KillEntityTask(entity));
                 }
                 break;
+            case "elytra":
+                    mod.runUserTask(new GetToXZWithElytraTask(1000,1000));
+                break;
             case "craft":
                 // Test de-equip
                 new Thread(() -> {

--- a/src/main/java/adris/altoclef/Playground.java
+++ b/src/main/java/adris/altoclef/Playground.java
@@ -13,6 +13,7 @@ import adris.altoclef.tasks.resources.TradeWithPiglinsTask;
 import adris.altoclef.tasks.examples.ExampleTask2;
 import adris.altoclef.tasks.misc.EquipArmorTask;
 import adris.altoclef.tasks.misc.PlaceBedAndSetSpawnTask;
+import adris.altoclef.tasks.misc.RepairToolTask;
 import adris.altoclef.tasks.construction.PlaceSignTask;
 import adris.altoclef.tasks.speedrun.*;
 import adris.altoclef.tasks.stupid.BeeMovieTask;
@@ -188,6 +189,10 @@ public class Playground {
                 ItemTarget material = new ItemTarget("iron_ore", 4);
                 mod.runUserTask(new SmeltInFurnaceTask(new SmeltTarget(target, material)));
                 break;
+            case "repair":
+                //mod.runUserTask(new RepairToolTask(new ItemTarget("leather_chestplate", 1), new ItemTarget("golden_boots", 1) , new ItemTarget("iron_sword", 1)));
+                mod.runUserTask(new RepairToolTask());
+            break;
             case "avoid":
                 // Test block break predicate
                 mod.getBehaviour().avoidBlockBreaking((BlockPos b) -> (-1000 < b.getX() && b.getX() < 1000)

--- a/src/main/java/adris/altoclef/TaskCatalogue.java
+++ b/src/main/java/adris/altoclef/TaskCatalogue.java
@@ -274,7 +274,7 @@ public class TaskCatalogue {
             alias("eye_of_ender", "ender_eye");
             shapedRecipe2x2("fermented_spider_eye", Items.FERMENTED_SPIDER_EYE, 1, "brown_mushroom", "sugar", o, "spider_eye");
             shapedRecipe3x3("fire_charge", Items.FIRE_CHARGE, 3, o, "blaze_powder", o, o, "coal", o, o, "gunpowder", o);
-            shapedRecipe2x2("firework_rocket", Items.FIREWORK_ROCKET, 2, "paper", "gunpowder", o, o);
+            shapedRecipe2x2("firework_rocket", Items.FIREWORK_ROCKET, 3, "paper", "gunpowder", o, o);
             shapedRecipe2x2("flower_banner_pattern", Items.FLOWER_BANNER_PATTERN, 1, "paper", "oxeye_daisy", o, o);
             simple("magma_cream", Items.MAGMA_CREAM, CollectMagmaCreamTask::new);
             // Slabs + Stairs + Walls

--- a/src/main/java/adris/altoclef/TaskCatalogue.java
+++ b/src/main/java/adris/altoclef/TaskCatalogue.java
@@ -274,6 +274,7 @@ public class TaskCatalogue {
             alias("eye_of_ender", "ender_eye");
             shapedRecipe2x2("fermented_spider_eye", Items.FERMENTED_SPIDER_EYE, 1, "brown_mushroom", "sugar", o, "spider_eye");
             shapedRecipe3x3("fire_charge", Items.FIRE_CHARGE, 3, o, "blaze_powder", o, o, "coal", o, o, "gunpowder", o);
+            shapedRecipe2x2("firework_rocket", Items.FIREWORK_ROCKET, 2, "paper", "gunpowder", o, o);
             shapedRecipe2x2("flower_banner_pattern", Items.FLOWER_BANNER_PATTERN, 1, "paper", "oxeye_daisy", o, o);
             simple("magma_cream", Items.MAGMA_CREAM, CollectMagmaCreamTask::new);
             // Slabs + Stairs + Walls

--- a/src/main/java/adris/altoclef/chains/MLGBucketFallChain.java
+++ b/src/main/java/adris/altoclef/chains/MLGBucketFallChain.java
@@ -102,7 +102,7 @@ public class MLGBucketFallChain extends SingleTaskChain implements ITaskOverride
     }
 
     public boolean isFallingOhNo(AltoClef mod) {
-        if (!mod.getModSettings().shouldAutoMLGBucket()) {
+        if (!mod.getModSettings().shouldAutoMLGBucket() || mod.getBehaviour().disableDefence()) {
             return false;
         }
         if (!mod.getItemStorage().hasItem(Items.WATER_BUCKET)) {

--- a/src/main/java/adris/altoclef/chains/MobDefenseChain.java
+++ b/src/main/java/adris/altoclef/chains/MobDefenseChain.java
@@ -80,7 +80,7 @@ public class MobDefenseChain extends SingleTaskChain {
             return Float.NEGATIVE_INFINITY;
         }
 
-        if (!mod.getModSettings().isMobDefense()) {
+        if (!mod.getModSettings().isMobDefense() || mod.getBehaviour().disableDefence()) {
             return Float.NEGATIVE_INFINITY;
         }
 

--- a/src/main/java/adris/altoclef/commands/GotoWithElytraCommand.java
+++ b/src/main/java/adris/altoclef/commands/GotoWithElytraCommand.java
@@ -1,0 +1,21 @@
+package adris.altoclef.commands;
+
+import adris.altoclef.AltoClef;
+import adris.altoclef.commandsystem.Arg;
+import adris.altoclef.commandsystem.ArgParser;
+import adris.altoclef.commandsystem.Command;
+import adris.altoclef.commandsystem.CommandException;
+import adris.altoclef.tasks.movement.GetToXZWithElytraTask;
+
+public class GotoWithElytraCommand extends Command {
+    public GotoWithElytraCommand() throws CommandException {
+        super("elytra", "Tell bot to travel to a set of coordinates using Elytra", new Arg(Integer.class, "x"), new Arg(Integer.class, "z"));
+    }
+
+    @Override
+    protected void call(AltoClef mod, ArgParser parser) throws CommandException {
+        int x = parser.get(Integer.class);
+        int z = parser.get(Integer.class);
+        mod.runUserTask(new GetToXZWithElytraTask(x,z), this::finish);
+    }
+}

--- a/src/main/java/adris/altoclef/tasks/misc/RepairToolTask.java
+++ b/src/main/java/adris/altoclef/tasks/misc/RepairToolTask.java
@@ -1,0 +1,197 @@
+package adris.altoclef.tasks.misc;
+
+import adris.altoclef.AltoClef;
+import adris.altoclef.Debug;
+import adris.altoclef.tasks.entity.KillEntityTask;
+import adris.altoclef.tasks.movement.GetToBlockTask;
+import adris.altoclef.tasks.movement.TimeoutWanderTask;
+import adris.altoclef.tasksystem.Task;
+import adris.altoclef.util.ItemTarget;
+import adris.altoclef.util.helpers.StorageHelper;
+import adris.altoclef.util.slots.Slot;
+import adris.altoclef.util.slots.PlayerSlot;
+import adris.altoclef.util.helpers.ItemHelper;
+import net.minecraft.item.Items;
+import baritone.api.utils.input.Input;
+import net.minecraft.entity.mob.ZombieEntity;
+import net.minecraft.entity.ExperienceOrbEntity;
+import adris.altoclef.util.csharpisbetter.TimerGame;
+import adris.altoclef.util.helpers.LookHelper;
+import baritone.api.utils.Rotation;
+import net.minecraft.entity.Entity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.item.ItemStack;
+import java.util.List;
+import java.util.Optional;
+import java.util.Arrays;
+
+public class RepairToolTask extends Task {
+
+    private ItemTarget[] _toRepair;
+    private boolean _finished;
+    private final TimerGame _throwTimer = new TimerGame(0.5);
+
+    public RepairToolTask(ItemTarget... toRepair) {
+        _toRepair = toRepair;
+    }
+    public RepairToolTask() { //If this task is called without itemtarget, repair anything we can
+        this(
+            new ItemTarget(ItemHelper.NETHERITE_ARMORS),
+            new ItemTarget(ItemHelper.NETHERITE_TOOLS),
+            new ItemTarget(Items.ELYTRA),
+            new ItemTarget(ItemHelper.DIAMOND_ARMORS),
+            new ItemTarget(ItemHelper.DIAMOND_TOOLS),
+            new ItemTarget(ItemHelper.IRON_ARMORS),
+            new ItemTarget(ItemHelper.IRON_TOOLS),
+            new ItemTarget(ItemHelper.GOLDEN_ARMORS),
+            new ItemTarget(ItemHelper.GOLDEN_TOOLS),
+            new ItemTarget(ItemHelper.STONE_TOOLS),
+            new ItemTarget(ItemHelper.LEATHER_ARMORS),
+            new ItemTarget(ItemHelper.WOODEN_TOOLS),
+            new ItemTarget(Items.FISHING_ROD),
+            new ItemTarget(Items.FLINT_AND_STEEL),
+            new ItemTarget(Items.CARROT_ON_A_STICK),
+            new ItemTarget(Items.SHEARS),
+            new ItemTarget(Items.BOW),
+            new ItemTarget(Items.SHIELD),
+            new ItemTarget(Items.TRIDENT),
+            new ItemTarget(Items.CROSSBOW),
+            new ItemTarget(Items.WARPED_FUNGUS_ON_A_STICK),
+            new ItemTarget(Items.BOW)
+        );
+    }   
+    @Override
+    protected void onStart(AltoClef mod) {
+        _throwTimer.reset();
+        _toRepair = Arrays.stream(_toRepair).filter(target -> needRepair(mod, target)).toArray(ItemTarget[]::new); //Filter out items type we can't repair
+        Optional<ItemTarget> ItemTargetOPTRepair = Arrays.stream(_toRepair).findFirst(); //Get the first element in our list
+        if (!ItemTargetOPTRepair.isPresent()) {
+            Debug.logWarning("There is nothing to repair");
+        }
+    }
+
+    @Override
+    protected Task onTick(AltoClef mod) {
+        //We start this task by filtering out every item type that we can't repair :
+        //All items without mending or with no damage
+        _toRepair = Arrays.stream(_toRepair).filter(target -> needRepair(mod, target)).toArray(ItemTarget[]::new);
+        
+        //After that, we get the first item type to repair on the list
+        Optional<ItemTarget> ItemTargetOPTRepair = Arrays.stream(_toRepair).findFirst();
+        
+        if (ItemTargetOPTRepair.isPresent()) { //If the list is not empty
+            ItemTarget ItemTargetRepair = ItemTargetOPTRepair.get(); //We get the (real) first item on the list
+            
+            List<Slot> SlotRepair = mod.getItemStorage().getSlotsWithItemPlayerInventory(false, ItemTargetRepair.getMatches()); //And we get a list of every slot with that item
+            
+            Slot SlotRepairTarget = new PlayerSlot(-1); //Placeholder slot, will never get used if not replaced
+            boolean FoundSomethingToRepair = false; //Will be set if we find the slot with the item to repair
+            for (int i = 0; i < SlotRepair.size(); ++i) { //For every item slot that is on our list
+                if (!FoundSomethingToRepair & StorageHelper.getItemStackInSlot(SlotRepair.get(i)).getDamage() != 0) { //if we can repair it
+                    if (haveMending(mod,StorageHelper.getItemStackInSlot(SlotRepair.get(i)))) { //and it have mending
+                        SlotRepairTarget = SlotRepair.get(i); //Replace the placeholder slot with the slot we found
+                        FoundSomethingToRepair = true;
+                    }
+                }
+            }
+            if (FoundSomethingToRepair) { //If we found our slot, we can now repair the item !
+                setDebugState("Repairing "+StorageHelper.getItemStackInSlot(SlotRepairTarget).getName().getString());
+                if (!_throwTimer.elapsed()){ //If we just used a experience bottle, get the item in our hand to repair
+                    mod.getSlotHandler().forceEquipSlot(SlotRepairTarget);
+                    return null;
+                }
+                //Get the nearest experience orb
+                Optional<Entity> expentityOPT = mod.getEntityTracker().getClosestEntity(mod.getPlayer().getPos(), ExperienceOrbEntity.class);
+                if (expentityOPT.isPresent()) { //if there is one
+                    Entity expentity = expentityOPT.get(); //get it
+                    if (expentity.getBlockPos().isWithinDistance(mod.getPlayer().getPos(), 3)) { //and if the orb is near the player
+                        mod.getSlotHandler().forceEquipSlot(SlotRepairTarget); //get the item in our hand to repair the item
+                    };
+                    return new GetToBlockTask(expentity.getBlockPos()); //go to the orb too
+                }
+                if (mod.getItemStorage().hasItem(Items.EXPERIENCE_BOTTLE)) { //if we have some experience bottle
+                    if (_throwTimer.elapsed()) { //the timer for throwing a experience bottle
+                        if (!LookHelper.isLookingAt(mod, new Rotation(0, 90))) {
+                            LookHelper.lookAt(mod, new Rotation(0, 90)); //Look at our feet
+                        }
+                        mod.getSlotHandler().forceEquipItem(Items.EXPERIENCE_BOTTLE); //equip it
+                        mod.getInputControls().tryPress(Input.CLICK_RIGHT); //and throw it
+                        _throwTimer.reset();
+                    }
+                    return null;
+                }
+                
+                //So we don't have any experience bottle, we will kill some zombies to get XP
+                Optional<Entity> entity = mod.getEntityTracker().getClosestEntity(mod.getPlayer().getPos(), ZombieEntity.class); //Find a zombie
+                if (entity.isPresent()) {
+                    return new KillEntityTask(entity.get()); //And kill it
+                }
+                return new TimeoutWanderTask(); //If there is no zombie, wander
+            }
+        } //If there is no items in the list of itemtype to repair, it means there is nothing to repair :)
+        _finished = true;
+        return null;
+    }
+
+    @Override
+    public boolean isFinished(AltoClef mod) {
+        return _finished;
+    }
+    //Check if a type of item can be repaired.
+    public static boolean needRepair(AltoClef mod, ItemTarget target) {
+        List<Slot> SlotRepair = mod.getItemStorage().getSlotsWithItemPlayerInventory(false, target.getMatches());
+        boolean FoundSomethingToRepair = false;
+        for (int i = 0; i < SlotRepair.size(); ++i) {
+            if (!FoundSomethingToRepair & StorageHelper.getItemStackInSlot(SlotRepair.get(i)).getDamage() != 0) {
+                if (haveMending(mod,StorageHelper.getItemStackInSlot(SlotRepair.get(i)))) {
+                    FoundSomethingToRepair = true;
+                }
+            }
+        }
+        return FoundSomethingToRepair;
+    }
+    //Will get the durability of an item in accordance of the ItemTarget.
+    //Return the durability of one of the item, or -1 if all targeted items is repaired or doesn't have the targeted item
+    public static int getDurabilityOfRepairableItem(AltoClef mod, ItemTarget target) {
+        List<Slot> SlotRepair = mod.getItemStorage().getSlotsWithItemPlayerInventory(false, target.getMatches());
+        for (int i = 0; i < SlotRepair.size(); ++i) {
+            if (StorageHelper.getItemStackInSlot(SlotRepair.get(i)).getDamage() != 0) {
+                if (haveMending(mod,StorageHelper.getItemStackInSlot(SlotRepair.get(i)))) {
+                    return StorageHelper.getItemStackInSlot(SlotRepair.get(i)).getMaxDamage()-StorageHelper.getItemStackInSlot(SlotRepair.get(i)).getDamage();
+                }
+            }
+        }
+        return -1;
+    }
+
+    //Test if the itemstack have mending on it
+    public static boolean haveMending(AltoClef mod, ItemStack target) {
+        boolean canRepair = false;
+        for (NbtElement elm : target.getEnchantments()) {
+            NbtCompound comp = (NbtCompound) elm;
+            if (comp.getString("id").equals("minecraft:mending")) {
+                canRepair = true;
+            }
+        }
+        return canRepair;
+    }
+    @Override
+    protected void onStop(AltoClef mod, Task interruptTask) {
+
+    }
+
+    @Override
+    protected boolean isEqual(Task other) {
+        if (other instanceof RepairToolTask task) {
+            return Arrays.equals(task._toRepair, _toRepair);
+        }
+        return false;
+    }
+
+    @Override
+    protected String toDebugString() {
+        return "Repairing an item";
+    }
+
+}

--- a/src/main/java/adris/altoclef/tasks/movement/GetToXZWithElytraTask.java
+++ b/src/main/java/adris/altoclef/tasks/movement/GetToXZWithElytraTask.java
@@ -1,23 +1,38 @@
 package adris.altoclef.tasks.movement;
 
 import adris.altoclef.AltoClef;
-import net.minecraft.item.Items;
+import adris.altoclef.Debug;
 import adris.altoclef.util.helpers.StorageHelper;
 import adris.altoclef.util.helpers.ItemHelper;
 import adris.altoclef.util.ItemTarget;
+import adris.altoclef.util.slots.PlayerSlot;
+import adris.altoclef.util.helpers.LookHelper;
 import adris.altoclef.TaskCatalogue;
-import adris.altoclef.Debug;
 import adris.altoclef.tasks.movement.GetToBlockTask;
 import adris.altoclef.tasks.movement.TimeoutWanderTask;
+import adris.altoclef.tasks.movement.GetToYTask;
+import adris.altoclef.tasks.movement.GetToXZTask;
 import adris.altoclef.tasks.slot.MoveItemToSlotFromInventoryTask;
-import adris.altoclef.util.slots.PlayerSlot;
 import adris.altoclef.tasks.misc.EquipArmorTask;
+import adris.altoclef.util.helpers.WorldHelper;
 import adris.altoclef.tasksystem.Task;
+import adris.altoclef.util.csharpisbetter.TimerGame;
+import baritone.api.utils.input.Input;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ingame.InventoryScreen;
+import net.minecraft.item.Items;
 import net.minecraft.block.BlockState;
+import baritone.api.utils.Rotation;
 import net.minecraft.block.Blocks;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.client.gui.screen.ingame.InventoryScreen;
+import net.minecraft.world.event.GameEvent;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.util.math.Vec3i;
 
 import java.util.Optional;
+
+import static net.minecraft.world.event.GameEvent.ELYTRA_FREE_FALL;
 
 public class GetToXZWithElytraTask extends Task {
 
@@ -25,51 +40,143 @@ public class GetToXZWithElytraTask extends Task {
     private boolean _isFinished;
     private boolean _isMovingElytra = false;
     private boolean _isCollectingFireWork = false;
+    private boolean _isFlyRunning = false;
+    private boolean _hasJumped = false;
+    private boolean _wasMovingToSurface = false;
+    private boolean _wasDoingWanderTask = false;
+    private double _oldCoordsY;
+    private final TimerGame _fireWorkTimer = new TimerGame(3);
+    private final TimerGame _wanderTimer = new TimerGame(5);
+    private final TimerGame _jumpTimer = new TimerGame(0.1);
 
     public GetToXZWithElytraTask(int x, int z) {
         _x = x;
         _z = z;
     }
-
     @Override
     protected void onStart(AltoClef mod) {
-        
+        _jumpTimer.reset();
+        _fireWorkTimer.reset();
     }
 
     @Override
     protected Task onTick(AltoClef mod) {
+        double dist = mod.getPlayer().getPos().distanceTo(new Vec3d(_x, mod.getPlayer().getPos().y, _z)); //Calculate distance
+        if (!_isFlyRunning) {
+            mod.getBehaviour().disableDefence(false); //Enable mob defence
+            if ((int)dist == 0) { //We are where we need to go !
+                _isFinished = true;
+                return null;
+            }
+            if (dist < 64) { //We are near, but not exactly where we need to go
+                setDebugState("Walking to goal");
+                return new GetToXZTask(_x, _z);
+            }
 
-        //If we don't have elytra, cancel the task
-        if (!mod.getItemStorage().hasItem(Items.ELYTRA) && !_isMovingElytra) {
-            Debug.logWarning("We don't have an elytra");
-            _isFinished = true;
-            return null;
+            //If we don't have elytra, cancel the task
+            if (!mod.getItemStorage().hasItem(Items.ELYTRA) && !_isMovingElytra && StorageHelper.getItemStackInSlot(new PlayerSlot(6)).getItem() != Items.ELYTRA) {
+                setDebugState("Walking to goal, since we don't have an elytra");
+                return new GetToXZTask(_x, _z);
+            }
+
+            //Get some fireworks if doesn't have many
+            if ((mod.getItemStorage().getItemCount(Items.FIREWORK_ROCKET) < 16 || _isCollectingFireWork) && mod.getItemStorage().getItemCount(Items.FIREWORK_ROCKET) < 32) {
+                _isCollectingFireWork = true;
+                setDebugState("Getting some fireworks");
+                return TaskCatalogue.getItemTask(Items.FIREWORK_ROCKET, 32);
+            }
+            _isCollectingFireWork = false;
+            
+            //Equip elytra, if didn't equipped,
+            setDebugState("Equipping elytra");
+            if (StorageHelper.getItemStackInSlot(new PlayerSlot(6)).getItem() != Items.ELYTRA) { 
+                //EquipArmorTask(Items.ELYTRA) crash the game for unknown reason
+                _isMovingElytra = true;
+                return new MoveItemToSlotFromInventoryTask(new ItemTarget(Items.ELYTRA, 1), new PlayerSlot(6));//So we move it manually
+            }
+            _isMovingElytra = false;
+
+            //We move to the surface, because we can't fly in caves :)
+            setDebugState("Moving to the surface");
+            int y = WorldHelper.getGroundHeight(mod, (int)mod.getPlayer().getPos().x, (int)mod.getPlayer().getPos().z);
+            if (y > mod.getPlayer().getPos().y && !_wasDoingWanderTask) {
+                _wasMovingToSurface = true;
+                _wanderTimer.reset();
+                return new GetToYTask(y); //Get to the surface
+            }
+            //Find a place to take off
+            setDebugState("Finding a place to take off");
+            if (_wasMovingToSurface && !_wanderTimer.elapsed()) {
+                _wasDoingWanderTask = true;
+                return new TimeoutWanderTask(); //move randomly until we find a place to fly
+            } else {
+                if (haveSpaceToTakeOff(mod,mod.getPlayer().getBlockPos())) { //if there is a space to fly
+                    _wasMovingToSurface = false;
+                    _wasDoingWanderTask = false;
+                    //this will allow the bot to continue and start trying to fly
+                } else {
+                    _wanderTimer.reset();
+                    return new TimeoutWanderTask();//wander again if there is some blocks
+                }
+            }
+        }
+        _isFlyRunning = true;
+        mod.getBehaviour().disableDefence(true); //Disable MobDefence and MLG, because it get interupted by that
+        
+        float yaw = LookHelper.getLookRotation(mod,new Vec3d(_x, 1, _z)).getYaw();
+        float pitch;
+
+        if (mod.getPlayer().getPos().y > 255) { //When flying up upper y=255
+            if (_oldCoordsY > mod.getPlayer().getPos().y && _fireWorkTimer.elapsed()) {
+                pitch = (float)10; //When flying down
+            } else {
+                pitch = (float)-10; // If we are flying up or using a firework
+            }
+        } else {
+            pitch = (float)-40; //When flying up under y=255, need to go in the sky!
+        }
+
+        setDebugState("Going to "+_x+" "+_z);
+        if (dist > 15) {
+            if (_jumpTimer.elapsed()) {//every 0.1 sec, jump, to enable elytra
+                mod.getInputControls().tryPress(Input.JUMP);
+                _jumpTimer.reset();
+            }
+            //If we can use firework rocket (every 5 secs), if we have one, and are under y=260
+            if (_fireWorkTimer.elapsed() && mod.getPlayer().getPos().y < 260 && mod.getItemStorage().hasItem(Items.FIREWORK_ROCKET)) {
+                int y = WorldHelper.getGroundHeight(mod, (int)mod.getPlayer().getPos().x, (int)mod.getPlayer().getPos().z); //Look if there is a block on top of us
+                if (y > mod.getPlayer().getPos().y) { //if there is one
+                    _isFlyRunning = false; //cancel the flight
+                    return null;
+                }
+                if (mod.getSlotHandler().forceEquipItem(Items.FIREWORK_ROCKET)) {//try to equip the item
+                    mod.getInputControls().tryPress(Input.CLICK_RIGHT); //and use it
+                    _fireWorkTimer.reset();
+                    pitch = (float)-10;
+                }
+            }
+        } else { //if the distance is under 15, we need to land slowly
+            setDebugState("Landing...");
+            pitch = (float)20; //look a bit down
+        }
+
+        if (dist > 6) { //if the distance is upper than 6
+            if (!LookHelper.isLookingAt(mod, new Rotation(yaw, pitch))) {
+                LookHelper.lookAt(mod, new Rotation(yaw, pitch)); //Look at where to look
+            }
             
         }
-
-        //Get some fireworks if doesn't have many
-        if ((mod.getItemStorage().getItemCount(Items.FIREWORK_ROCKET) < 16 || _isCollectingFireWork) && mod.getItemStorage().getItemCount(Items.FIREWORK_ROCKET) < 32) {
-            _isCollectingFireWork = true;
-            return TaskCatalogue.getItemTask(Items.FIREWORK_ROCKET, 32);
+        //if we have landed, and the distance is under 12 or we don't have any fireworks
+        if (_oldCoordsY == mod.getPlayer().getPos().y && (dist < 12 || !mod.getItemStorage().hasItem(Items.FIREWORK_ROCKET))) {
+            _isFlyRunning = false; //reset the whole task
         }
-        _isCollectingFireWork = false;
-        
-        //Equip elytra, if didn't equipped,
-        if (StorageHelper.getItemStackInSlot(new PlayerSlot(6)).getItem() != Items.ELYTRA) { 
-            //EquipArmorTask(Items.ELYTRA) crash the game for unknown reason
-            _isMovingElytra = true;
-            return new MoveItemToSlotFromInventoryTask(new ItemTarget(Items.ELYTRA, 1), new PlayerSlot(6));//So we move it manually
-        }
-        _isMovingElytra = false;
-
-
-        _isFinished = true;
+         _oldCoordsY = mod.getPlayer().getPos().y; //save old player y position
         return null;
-        
     }
 
     @Override
     protected void onStop(AltoClef mod, Task interruptTask) {
+        mod.getBehaviour().disableDefence(false);
     }
 
     @Override
@@ -81,9 +188,34 @@ public class GetToXZWithElytraTask extends Task {
     public boolean isFinished(AltoClef mod) {
         return _isFinished;
     }
-
     @Override
     protected String toDebugString() {
         return "Moving using Elytra";
+    }
+    private boolean haveSpaceToTakeOff(AltoClef mod, BlockPos pos) {
+        final Vec3i[] CHECK = new Vec3i[]{
+                new Vec3i(0, 0, 0),
+                new Vec3i(-1, 0, 0),
+                new Vec3i(1, 0, 0),
+                new Vec3i(0, 0, 1),
+                new Vec3i(-1, 0, 1),
+                new Vec3i(1, 0, 1),
+                new Vec3i(0, 0, -1),
+                new Vec3i(-1, 0, -1),
+                new Vec3i(1, 0, -1),
+                new Vec3i(0, 1, 0),
+                new Vec3i(-1, 1, 0),
+                new Vec3i(1, 1, 0),
+                new Vec3i(0, 1, 1),
+                new Vec3i(-1, 1, 1),
+                new Vec3i(1, 1, 1),
+                new Vec3i(0, 1, -1),
+                new Vec3i(-1, 1, -1),
+                new Vec3i(1, 1, -1),
+        };
+        for (Vec3i offs : CHECK) {
+            if (WorldHelper.isSolid(mod, pos.add(offs))) return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/adris/altoclef/tasks/movement/GetToXZWithElytraTask.java
+++ b/src/main/java/adris/altoclef/tasks/movement/GetToXZWithElytraTask.java
@@ -1,0 +1,80 @@
+package adris.altoclef.tasks.movement;
+
+import adris.altoclef.AltoClef;
+import net.minecraft.item.Items;
+import adris.altoclef.util.helpers.StorageHelper;
+import adris.altoclef.util.helpers.ItemHelper;
+import adris.altoclef.util.ItemTarget;
+import adris.altoclef.Debug;
+import adris.altoclef.tasks.movement.GetToBlockTask;
+import adris.altoclef.tasks.movement.TimeoutWanderTask;
+import adris.altoclef.tasks.slot.MoveItemToSlotFromInventoryTask;
+import adris.altoclef.util.slots.PlayerSlot;
+import adris.altoclef.tasks.misc.EquipArmorTask;
+import adris.altoclef.tasksystem.Task;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.util.math.BlockPos;
+
+import java.util.Optional;
+
+public class GetToXZWithElytraTask extends Task {
+
+    private final int _x, _z;
+    private boolean _isFinished;
+    private boolean _isMovingElytra = false;
+
+    public GetToXZWithElytraTask(int x, int z) {
+        _x = x;
+        _z = z;
+    }
+
+    @Override
+    protected void onStart(AltoClef mod) {
+        
+    }
+
+    @Override
+    protected Task onTick(AltoClef mod) {
+
+        //If we don't have elytra, cancel the task
+        if (!mod.getItemStorage().hasItem(Items.ELYTRA) && !_isMovingElytra) {
+            Debug.logWarning("We don't have an elytra");
+            _isFinished = true;
+            return null;
+            
+        }
+
+        //Equip elytra, if didn't equipped,
+        if (StorageHelper.getItemStackInSlot(new PlayerSlot(6)).getItem() != Items.ELYTRA) { 
+            //EquipArmorTask(Items.ELYTRA) crash the game for unknown reason
+            _isMovingElytra = true;
+            return new MoveItemToSlotFromInventoryTask(new ItemTarget(Items.ELYTRA, 1), new PlayerSlot(6));//So we move it manually
+        }
+        _isMovingElytra = false;
+
+
+        _isFinished = true;
+        return null;
+        
+    }
+
+    @Override
+    protected void onStop(AltoClef mod, Task interruptTask) {
+    }
+
+    @Override
+    protected boolean isEqual(Task other) {
+        return other instanceof GetToXZWithElytraTask;
+    }
+
+    @Override
+    public boolean isFinished(AltoClef mod) {
+        return _isFinished;
+    }
+
+    @Override
+    protected String toDebugString() {
+        return "Moving using Elytra";
+    }
+}

--- a/src/main/java/adris/altoclef/tasks/movement/GetToXZWithElytraTask.java
+++ b/src/main/java/adris/altoclef/tasks/movement/GetToXZWithElytraTask.java
@@ -191,12 +191,12 @@ public class GetToXZWithElytraTask extends Task {
             
         }
         //if we have landed, and the distance is under 12 or we don't have any fireworks
-        if (_oldCoordsY == mod.getPlayer().getPos().y && (dist < 12 || !mod.getItemStorage().hasItem(Items.FIREWORK_ROCKET))) {
+        if (isOnGround(mod) && (dist < 12 || !mod.getItemStorage().hasItem(Items.FIREWORK_ROCKET))) {
             if (StorageHelper.getItemStackInSlot(new PlayerSlot(6)).getItem() == Items.ELYTRA) { //Unequip elytra
                 return new ClickSlotTask(new PlayerSlot(6)); //Click on the elytra in the armor slot
             } else if (!StorageHelper.getItemStackInCursorSlot().isEmpty()){ //Once it's in the cursor slot
                 List<Slot> airslot = mod.getItemStorage().getSlotsWithItemPlayerInventory(false, Items.AIR); //Click on a empty inv slot
-                if (airslot.size() == 0) {
+                if (airslot.isEmpty()) {
                     return new EnsureFreeInventorySlotTask(); //If there is no space
                 } else {
                     return new ClickSlotTask(airslot.get(0)); //Click on the slot to put elytra back in inventory
@@ -208,7 +208,9 @@ public class GetToXZWithElytraTask extends Task {
          _oldCoordsY = mod.getPlayer().getPos().y; //save the old player y position
         return null;
     }
-
+    private boolean isOnGround(AltoClef mod) {
+        return mod.getPlayer().isSwimming() || mod.getPlayer().isTouchingWater() || mod.getPlayer().isOnGround() || mod.getPlayer().isClimbing();
+    }   
     @Override
     protected void onStop(AltoClef mod, Task interruptTask) {
         mod.getBehaviour().disableDefence(false);

--- a/src/main/java/adris/altoclef/tasks/movement/GetToXZWithElytraTask.java
+++ b/src/main/java/adris/altoclef/tasks/movement/GetToXZWithElytraTask.java
@@ -5,6 +5,7 @@ import net.minecraft.item.Items;
 import adris.altoclef.util.helpers.StorageHelper;
 import adris.altoclef.util.helpers.ItemHelper;
 import adris.altoclef.util.ItemTarget;
+import adris.altoclef.TaskCatalogue;
 import adris.altoclef.Debug;
 import adris.altoclef.tasks.movement.GetToBlockTask;
 import adris.altoclef.tasks.movement.TimeoutWanderTask;
@@ -23,6 +24,7 @@ public class GetToXZWithElytraTask extends Task {
     private final int _x, _z;
     private boolean _isFinished;
     private boolean _isMovingElytra = false;
+    private boolean _isCollectingFireWork = false;
 
     public GetToXZWithElytraTask(int x, int z) {
         _x = x;
@@ -45,6 +47,13 @@ public class GetToXZWithElytraTask extends Task {
             
         }
 
+        //Get some fireworks if doesn't have many
+        if ((mod.getItemStorage().getItemCount(Items.FIREWORK_ROCKET) < 16 || _isCollectingFireWork) && mod.getItemStorage().getItemCount(Items.FIREWORK_ROCKET) < 32) {
+            _isCollectingFireWork = true;
+            return TaskCatalogue.getItemTask(Items.FIREWORK_ROCKET, 32);
+        }
+        _isCollectingFireWork = false;
+        
         //Equip elytra, if didn't equipped,
         if (StorageHelper.getItemStackInSlot(new PlayerSlot(6)).getItem() != Items.ELYTRA) { 
             //EquipArmorTask(Items.ELYTRA) crash the game for unknown reason

--- a/usage.md
+++ b/usage.md
@@ -20,7 +20,7 @@ Commands are prefixed with `@`. Here's a list along with their functions:
 | `list` | Prints a list of all get-able items | |
 | `give [player=<you>] [item] [quantity=1]` | Gives `[player]` `[quantity]` units of `[item]`, getting said items if the bot doesn't have them. If sent via `/msg`, will follow the player who sent the command. | `/msg Bot give iron_pickaxe` |
 | `goto [x] [y] [z] [dimension=<current>]` | Goes to (`[x]`,`[y]`, `[z]`) in a given `[dimension]`. Travels to `[dimension]` if not there already. Can also omit coordinates to just go to a dimension. Passing 2 values as coordinates goes to X Z coordinates instead. | `@goto 100 64 100 overworld` `@goto nether` `@goto 100 100` |
-| `elytra [x] [z]` | Goes to (`[x]`, `[z]`) using an elytra, it will do the same thing as `goto [x] [z]` if doesn't have one| `@elytra 1000 500` |
+| `elytra [x] [z]` | Goes to (`[x]`, `[z]`) using an elytra, it will do the same thing as `goto [x] [z]` if we don't have one| `@elytra 1000 500` |
 | `inventory [item?]` | Prints the bots inventory, OR how many items of a specific type the bot has. Mostly useful when running through `/msg`. | `/msg Bot inventory` `/msg Bot inventory cobblestone` |
 | `locate_structure [structure_type]` | Attempts to locate a `[structure_type]` structure. Can find strongholds or desert temples. | `@locate_structure stronghold`, `@locate_structure desert_temple` |
 | `punk [player]` | Attacks `[player]`. | |

--- a/usage.md
+++ b/usage.md
@@ -20,6 +20,7 @@ Commands are prefixed with `@`. Here's a list along with their functions:
 | `list` | Prints a list of all get-able items | |
 | `give [player=<you>] [item] [quantity=1]` | Gives `[player]` `[quantity]` units of `[item]`, getting said items if the bot doesn't have them. If sent via `/msg`, will follow the player who sent the command. | `/msg Bot give iron_pickaxe` |
 | `goto [x] [y] [z] [dimension=<current>]` | Goes to (`[x]`,`[y]`, `[z]`) in a given `[dimension]`. Travels to `[dimension]` if not there already. Can also omit coordinates to just go to a dimension. Passing 2 values as coordinates goes to X Z coordinates instead. | `@goto 100 64 100 overworld` `@goto nether` `@goto 100 100` |
+| `elytra [x] [z]` | Goes to (`[x]`, `[z]`) using an elytra, it will do the same thing as `goto [x] [z]` if doesn't have one| `@elytra 1000 500` |
 | `inventory [item?]` | Prints the bots inventory, OR how many items of a specific type the bot has. Mostly useful when running through `/msg`. | `/msg Bot inventory` `/msg Bot inventory cobblestone` |
 | `locate_structure [structure_type]` | Attempts to locate a `[structure_type]` structure. Can find strongholds or desert temples. | `@locate_structure stronghold`, `@locate_structure desert_temple` |
 | `punk [player]` | Attacks `[player]`. | |


### PR DESCRIPTION
I started woking on this about a week ago mostly for fun, and i think it's ready

In this pull request :
- Added the firework_rocket (level 1) in taskCatalogue
- Added a way of disabling mobDefence and the MLG from a task, it's inside BotBehaviour
- Created the task GetToXZWithElytraTask :
   - Will get fireworks if needed
   - Will fly down if the elytra is going to break
   - Will travel to XZ by foot if it doesn't have an elytra, or it have a broken one
   - Will repair the elytra if it have mending on it
   - Some footage of the bot running the task : https://youtu.be/k0qzBwkhkd4
 - Added a command to travel using elytra : `@elytra <x> <z>`
 - Added the elytra command and its usage in usage.md
 - Created the task RepairToolTask :
   - Will use bottle of experience if have any
   - Will kill some zombies if doesn't have bottle of experience
   - Can repair any tool that have mending on it
   - Test command : `@test repair`
   - Doesn't repair equipped armor
   - Some footage of the repair task : https://youtu.be/ccv1X0IKpm0
 
And i think i listed everything that i added/edited in that PR.