### PR TITLE
Fix issue with butler not recognising some messages + other big and small fixes and qol additions

### DIFF
--- a/src/main/java/adris/altoclef/butler/Butler.java
+++ b/src/main/java/adris/altoclef/butler/Butler.java
@@ -125,7 +125,7 @@ public class Butler {
         _commandFinished = false;
         _currentUser = username;
         sendWhisper("Command Executing: " + message, MessagePriority.TIMELY);
-        AltoClef.getCommandExecutor().execute("@"+message, () -> {
+        AltoClef.getCommandExecutor().execute(_mod.getModSettings().getCommandPrefix()+message, () -> {
             // On finish
             sendWhisper("Command Finished: " + message, MessagePriority.TIMELY);
             if (!_commandInstantRan) {

--- a/src/main/java/adris/altoclef/butler/Butler.java
+++ b/src/main/java/adris/altoclef/butler/Butler.java
@@ -125,7 +125,7 @@ public class Butler {
         _commandFinished = false;
         _currentUser = username;
         sendWhisper("Command Executing: " + message, MessagePriority.TIMELY);
-        AltoClef.getCommandExecutor().execute(_mod.getModSettings().getCommandPrefix()+message, () -> {
+        AltoClef.getCommandExecutor().execute("@"+message, () -> {
             // On finish
             sendWhisper("Command Finished: " + message, MessagePriority.TIMELY);
             if (!_commandInstantRan) {

--- a/src/main/java/adris/altoclef/butler/Butler.java
+++ b/src/main/java/adris/altoclef/butler/Butler.java
@@ -125,7 +125,8 @@ public class Butler {
         _commandFinished = false;
         _currentUser = username;
         sendWhisper("Command Executing: " + message, MessagePriority.TIMELY);
-        AltoClef.getCommandExecutor().execute(message, () -> {
+        prefix = ButlerConfig.getInstance().requirePrefixMsg ? _mod.getModSettings().getCommandPrefix() : "";
+        AltoClef.getCommandExecutor().execute(prefix+message, () -> {
             // On finish
             sendWhisper("Command Finished: " + message, MessagePriority.TIMELY);
             if (!_commandInstantRan) {

--- a/src/main/java/adris/altoclef/butler/Butler.java
+++ b/src/main/java/adris/altoclef/butler/Butler.java
@@ -125,7 +125,7 @@ public class Butler {
         _commandFinished = false;
         _currentUser = username;
         sendWhisper("Command Executing: " + message, MessagePriority.TIMELY);
-        prefix = ButlerConfig.getInstance().requirePrefixMsg ? _mod.getModSettings().getCommandPrefix() : "";
+        String prefix = ButlerConfig.getInstance().requirePrefixMsg ? _mod.getModSettings().getCommandPrefix() : "";
         AltoClef.getCommandExecutor().execute(prefix+message, () -> {
             // On finish
             sendWhisper("Command Finished: " + message, MessagePriority.TIMELY);

--- a/src/main/java/adris/altoclef/butler/Butler.java
+++ b/src/main/java/adris/altoclef/butler/Butler.java
@@ -125,7 +125,7 @@ public class Butler {
         _commandFinished = false;
         _currentUser = username;
         sendWhisper("Command Executing: " + message, MessagePriority.TIMELY);
-        AltoClef.getCommandExecutor().execute(_mod.getModSettings().getCommandPrefix()+message, () -> {
+        AltoClef.getCommandExecutor().execute(message, () -> {
             // On finish
             sendWhisper("Command Finished: " + message, MessagePriority.TIMELY);
             if (!_commandInstantRan) {

--- a/src/main/java/adris/altoclef/butler/Butler.java
+++ b/src/main/java/adris/altoclef/butler/Butler.java
@@ -46,14 +46,12 @@ public class Butler {
 
         // Receive system events
         EventBus.subscribe(ChatMessageEvent.class, evt -> {
-            if (evt.messageType == MessageType.SYSTEM) {
-                boolean debug = ButlerConfig.getInstance().whisperFormatDebug;
-                String message = evt.message.getString();
-                if (debug) {
-                    Debug.logMessage("RECEIVED WHISPER: \"" + message + "\".");
-                }
-                _mod.getButler().receiveMessage(message);
+            boolean debug = ButlerConfig.getInstance().whisperFormatDebug;
+            String message = evt.message.getString();
+            if (debug) {
+                Debug.logMessage("RECEIVED WHISPER: \"" + message + "\".");
             }
+            _mod.getButler().receiveMessage(message);
         });
     }
 
@@ -86,7 +84,9 @@ public class Butler {
             if (debug) {
                 Debug.logMessage("    Rejecting: User \"" + username + "\" is not authorized.");
             }
-            sendWhisper(username, "Sorry, you're not authorized!", MessagePriority.UNAUTHORIZED);
+            if (ButlerConfig.getInstance().sendAuthorizationResponse) {
+                sendWhisper(username, ButlerConfig.getInstance().authorizationResponse.replace("{from}", username), MessagePriority.UNAUTHORIZED);
+            }
         }
     }
 
@@ -125,7 +125,7 @@ public class Butler {
         _commandFinished = false;
         _currentUser = username;
         sendWhisper("Command Executing: " + message, MessagePriority.TIMELY);
-        AltoClef.getCommandExecutor().execute("@" + message, () -> {
+        AltoClef.getCommandExecutor().execute(_mod.getModSettings().getCommandPrefix()+message, () -> {
             // On finish
             sendWhisper("Command Finished: " + message, MessagePriority.TIMELY);
             if (!_commandInstantRan) {

--- a/src/main/java/adris/altoclef/butler/Butler.java
+++ b/src/main/java/adris/altoclef/butler/Butler.java
@@ -85,7 +85,7 @@ public class Butler {
                 Debug.logMessage("    Rejecting: User \"" + username + "\" is not authorized.");
             }
             if (ButlerConfig.getInstance().sendAuthorizationResponse) {
-                sendWhisper(username, ButlerConfig.getInstance().authorizationResponse.replace("{from}", username), MessagePriority.UNAUTHORIZED);
+                sendWhisper(username, ButlerConfig.getInstance().failedAuthorizationResposne.replace("{from}", username), MessagePriority.UNAUTHORIZED);
             }
         }
     }

--- a/src/main/java/adris/altoclef/butler/ButlerConfig.java
+++ b/src/main/java/adris/altoclef/butler/ButlerConfig.java
@@ -62,8 +62,13 @@ public class ButlerConfig {
      * Use this to customize the response if "sendAuthorizationResponse"
      * 
      * You may use {from} to get sender username.
-     * 
-     * Disable this if you need to stay undercover.
      */
     public String authorizationResponse = "Sorry {from} but you are not authorized!";
+
+    /**
+     * Use this to choose if the prefix should be required in messages
+     * 
+     * Disable this if you want to be able to send normal messages and not butler commands.
+     */
+    public boolean requirePrefixMsg = true;
 }

--- a/src/main/java/adris/altoclef/butler/ButlerConfig.java
+++ b/src/main/java/adris/altoclef/butler/ButlerConfig.java
@@ -51,4 +51,19 @@ public class ButlerConfig {
      */
     public boolean whisperFormatDebug = false;
 
+    /**
+     * If set to true, will reply with "Sorry, you're not authorized!".
+     *
+     * Disable this if you need to stay undercover.
+     */
+    public boolean sendAuthorizationResponse = true;
+
+    /**
+     * Use this to customize the response if "sendAuthorizationResponse"
+     * 
+     * You may use {from} to get sender username.
+     * 
+     * Disable this if you need to stay undercover.
+     */
+    public String authorizationResponse = "Sorry {from} but you are not authorized!";
 }

--- a/src/main/java/adris/altoclef/butler/ButlerConfig.java
+++ b/src/main/java/adris/altoclef/butler/ButlerConfig.java
@@ -52,23 +52,22 @@ public class ButlerConfig {
     public boolean whisperFormatDebug = false;
 
     /**
-     * If set to true, will reply with "Sorry, you're not authorized!".
-     *
-     * Disable this if you need to stay undercover.
-     */
+    * Determines if failure messages should be sent to a non-authorized entity attempting to use butler
+    *
+    * Disable this if you need to stay undercover.
+    */
     public boolean sendAuthorizationResponse = true;
 
     /**
-     * Use this to customize the response if "sendAuthorizationResponse"
-     * 
-     * You may use {from} to get sender username.
-     */
-    public String authorizationResponse = "Sorry {from} but you are not authorized!";
+    * The response sent in a failed execution due to non-authorization
+    * @param from: the username of the player who triggered the failed authorization response
+    */
+    public String failedAuthorizationResposne = "Sorry {from} but you are not authorized!";
 
     /**
      * Use this to choose if the prefix should be required in messages
      * 
      * Disable this if you want to be able to send normal messages and not butler commands.
      */
-    public boolean requirePrefixMsg = true;
+    public boolean requirePrefixMsg = false;
 }

--- a/src/main/java/adris/altoclef/butler/WhisperChecker.java
+++ b/src/main/java/adris/altoclef/butler/WhisperChecker.java
@@ -74,7 +74,7 @@ public class WhisperChecker {
         _lastMessage = msg;
 
         for (String format : ButlerConfig.getInstance().whisperFormats) {
-            MessageResult check = tryParse(ourUsername, format, msg);
+            MessageResult check = tryParse(ourUsername, format.replace("{message}", mod.getModSettings().getCommandPrefix()+"{message}"), msg);
             if (check != null) {
                 String user = check.from;
                 String message = check.message;

--- a/src/main/java/adris/altoclef/butler/WhisperChecker.java
+++ b/src/main/java/adris/altoclef/butler/WhisperChecker.java
@@ -74,7 +74,7 @@ public class WhisperChecker {
         _lastMessage = msg;
 
         for (String format : ButlerConfig.getInstance().whisperFormats) {
-            MessageResult check = tryParse(ourUsername, format.replace("{message}", mod.getModSettings().getCommandPrefix()+"{message}"), msg);
+            MessageResult check = tryParse(ourUsername, format, msg);
             if (check != null) {
                 String user = check.from;
                 String message = check.message;


### PR DESCRIPTION
1. removed a useless if that checks if the messages are system or chat messages, 1. it does nothing 2. some servers send /msg as chat messages and the /msgs get ignored
2. added the ability to turn off the reply when someone who doesn't have permissions to use butler uses butler
3. added the ability to customize the reply when someone who doesn't have permissions to use butler uses butler. {from} may be used as a placeholder and will be replaced by the sender's username, {from} is optional and can be used more than once
4. added forgotten prefix check for butler
5. fixed issue where if you had changed prefix to something else butler would still use @