### PR TITLE
Manual crafting bug fix

### DIFF
--- a/src/main/java/adris/altoclef/Settings.java
+++ b/src/main/java/adris/altoclef/Settings.java
@@ -414,6 +414,12 @@ public class Settings implements IFailableConfigFile {
      * ],
      */
     private List<BlockRange> areasToProtect = Collections.emptyList();
+    
+    
+    /*
+     * If true open inventory during crafting in 2x2
+     */
+    private boolean openInvDuringCrafting = true;
 
 
     //////////////////////////////////////////////////////////////////////////////////////////
@@ -609,6 +615,11 @@ public class Settings implements IFailableConfigFile {
     public BlockPos getHomeBasePosition() {
         return homeBasePosition;
     }
+    
+    
+	public boolean openInvDuringCrafting() {
+		return openInvDuringCrafting;
+	}
 
     @Override
     public void onFailLoad() {

--- a/src/main/java/adris/altoclef/tasks/CraftGenericManuallyTask.java
+++ b/src/main/java/adris/altoclef/tasks/CraftGenericManuallyTask.java
@@ -55,7 +55,8 @@ public class CraftGenericManuallyTask extends Task implements ITaskUsesCraftingG
         // We need 9 sticks
         // plank recipe results in 4 sticks
         // this means 3 planks per slot
-        int requiredPerSlot = (int)Math.ceil((double) _target.getTargetCount() / _target.getRecipe().outputCount());
+        // BUT if we already have 7 sticks then we only need 1 plank per slot
+        int requiredPerSlot = (int)Math.ceil((double) (_target.getTargetCount() - mod.getItemStorage().getItemCount(_target.getOutputItem())) / _target.getRecipe().outputCount());
 
         // For each slot in table
         for (int craftSlot = 0; craftSlot < _target.getRecipe().getSlotCount(); ++craftSlot) {

--- a/src/main/java/adris/altoclef/tasks/CraftInInventoryTask.java
+++ b/src/main/java/adris/altoclef/tasks/CraftInInventoryTask.java
@@ -11,6 +11,9 @@ import adris.altoclef.util.slots.PlayerSlot;
 import adris.altoclef.util.slots.Slot;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.InventoryScreen;
 
 /**
  * Crafts an item within the 2x2 inventory crafting grid.
@@ -27,6 +30,8 @@ public class CraftInInventoryTask extends ResourceTask {
         _target = target;
         _collect = collect;
         _ignoreUncataloguedSlots = ignoreUncataloguedSlots;
+        private Screen invScreen;
+        private MinecraftClient client = MinecraftClient.getInstance();
     }
 
     public CraftInInventoryTask(RecipeTarget target) {
@@ -40,6 +45,7 @@ public class CraftInInventoryTask extends ResourceTask {
 
     @Override
     protected void onResourceStart(AltoClef mod) {
+        invScreen = new InventoryScreen(mod.getPlayer());
         mod.getBehaviour().push();
         // Our inventory slots are here for conversion
         int recSlot = 0;
@@ -77,6 +83,7 @@ public class CraftInInventoryTask extends ResourceTask {
         // No need to free inventory, output gets picked up.
 
             setDebugState("Crafting in inventory... for " + toGet);
+            if(mod.getModSettings().openInvDuringCrafting() && (client == null || client.currentScreen == null || !client.currentScreen.equals(invScreen))) client.setScreen(invScreen);
             return mod.getModSettings().shouldUseCraftingBookToCraft() ? new CraftGenericWithRecipeBooksTask(_target) : new CraftGenericManuallyTask(_target);
 
 
@@ -84,6 +91,7 @@ public class CraftInInventoryTask extends ResourceTask {
 
     @Override
     protected void onResourceStop(AltoClef mod, Task interruptTask) {
+        if(mod.getModSettings().openInvDuringCrafting() && (client != null && client.currentScreen != null && client.currentScreen.equals(invScreen))) client.setScreen(null);
         mod.getBehaviour().pop();
     }
 

--- a/src/main/java/adris/altoclef/tasks/CraftInInventoryTask.java
+++ b/src/main/java/adris/altoclef/tasks/CraftInInventoryTask.java
@@ -83,7 +83,7 @@ public class CraftInInventoryTask extends ResourceTask {
         // No need to free inventory, output gets picked up.
 
             setDebugState("Crafting in inventory... for " + toGet);
-            if(mod.getModSettings().openInvDuringCrafting() && (client == null || client.currentScreen == null || !client.currentScreen.equals(invScreen))) client.setScreen(invScreen);
+            if(mod.getModSettings().openInvDuringCrafting() && client != null && (client.currentScreen == null || !client.currentScreen.equals(invScreen))) client.setScreen(invScreen);
             return mod.getModSettings().shouldUseCraftingBookToCraft() ? new CraftGenericWithRecipeBooksTask(_target) : new CraftGenericManuallyTask(_target);
 
 


### PR DESCRIPTION
## Summary

Fixed calculation of how many items are required per slot to craft requested amount of items. 

For example:
We need 9 sticks
plank recipe results in 4 sticks
this means 3 planks per slot unless we already have 7 sticks in which case we only need 1 plank per slot

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] I have searched the open pull requests for duplicates.
- [x] If code changes were made then they have been tested.